### PR TITLE
Support M ISO property

### DIFF
--- a/MDLMol.pm
+++ b/MDLMol.pm
@@ -266,6 +266,15 @@ sub M_RAD {
     }
 }
 
+sub M_ISO {
+    my ($self, $mol, $line) = @_;
+    my ($m, $type, $n, %data) = split " ", $line;
+    while (my ($key, $val) = each %data) {
+        $val = $mol->atoms($key)->mass + $val;
+        $mol->atoms($key)->mass($val);
+    }
+}
+
 sub M_ALS {
     my ($self, $mol, $line) = @_;
 

--- a/MDLMol.pm
+++ b/MDLMol.pm
@@ -270,7 +270,6 @@ sub M_ISO {
     my ($self, $mol, $line) = @_;
     my ($m, $type, $n, %data) = split " ", $line;
     while (my ($key, $val) = each %data) {
-        $val = $mol->atoms($key)->mass + $val;
         $mol->atoms($key)->mass($val);
     }
 }


### PR DESCRIPTION
This PR implements support for isotopes read from `M ISO` lines. Partially fixes [RT#134837](https://rt.cpan.org/Ticket/Display.html?id=134837).